### PR TITLE
Typo in QuirrelDoc.h

### DIFF
--- a/QuirrelDoc.h
+++ b/QuirrelDoc.h
@@ -783,7 +783,7 @@ class Game // Native
 	/// Has a hard limit of 100 (will conflict with Dust Painting)
 	void CreateDust(Vector3 Origin, float Radius, Color Color);
 
-	/// @brief Use eExplosionType from the core module
+	/// @brief Use eExplosion from the core module
 	enum ExplosionType : uint32
 	{
 		NitroCell,


### PR DESCRIPTION
you actually call eExplosion and not eExplosionType when you're trying to get an ExplosionType from the core module.